### PR TITLE
fix: Edit scam type (#3) and re-link after revoke (#5)

### DIFF
--- a/src/includes/helpers.php
+++ b/src/includes/helpers.php
@@ -147,6 +147,21 @@ function updateIncidentStatus(int $incidentId, string $status): void {
            ->execute([$status, $incidentId]);
 }
 
+// ── Issue #3: Admin can update scam_category on an analysed incident ─
+function updateScamCategory(int $incidentId, string $category): bool {
+    // Strip tags and trim — category is a short label, no HTML needed
+    $category = trim(strip_tags($category));
+    if ($category === '' || strlen($category) > 100) return false;
+
+    $db   = getDB();
+    $stmt = $db->prepare(
+        'UPDATE analysis SET scam_category = ?, admin_override = 1
+         WHERE incident_id = ?'
+    );
+    $stmt->execute([$category, $incidentId]);
+    return $stmt->rowCount() > 0;
+}
+
 function deleteIncident(int $incidentId, int $userId, string $role): bool {
     $db = getDB();
     if ($role === 'admin') {
@@ -182,7 +197,6 @@ function notifyCaregivers(int $incidentId, int $elderUserId, int $probability, s
     $stmt->execute([$elderUserId]);
     $caregivers = $stmt->fetchAll();
 
-    // Also get elder name
     $nameStmt = $db->prepare('SELECT full_name FROM users WHERE user_id=?');
     $nameStmt->execute([$elderUserId]);
     $elderName = $nameStmt->fetchColumn() ?: 'An elder user';
@@ -197,7 +211,6 @@ function notifyCaregivers(int $incidentId, int $elderUserId, int $probability, s
         createNotification($incidentId, (int)$cg['caregiver_user_id'], $message, $notifType);
     }
 
-    // Also notify admins
     $adminStmt = $db->prepare('SELECT user_id FROM users WHERE role="admin" AND is_active=1');
     $adminStmt->execute();
     foreach ($adminStmt->fetchAll() as $admin) {
@@ -258,8 +271,10 @@ function approveLink(int $linkId): void {
     getDB()->prepare('UPDATE account_links SET status="active" WHERE link_id=?')->execute([$linkId]);
 }
 
+// ── Issue #5 fix: DELETE the row on revoke so the UNIQUE KEY allows re-linking ──
+// Previously SET status="revoked" blocked new INSERT due to the unique constraint.
 function revokeLink(int $linkId): void {
-    getDB()->prepare('UPDATE account_links SET status="revoked" WHERE link_id=?')->execute([$linkId]);
+    getDB()->prepare('DELETE FROM account_links WHERE link_id=?')->execute([$linkId]);
 }
 
 function getLinksForElder(int $elderUserId): array {
@@ -292,9 +307,9 @@ function e(string $val): string {
 
 function riskBadge(float $probability): string {
     $level = $probability >= RISK_HIGH ? 'high' : ($probability >= RISK_MEDIUM ? 'medium' : 'low');
-    $map   = ['high' => ['label'=>'High Risk','class'=>'badge-danger'],
-              'medium'=>['label'=>'Medium Risk','class'=>'badge-warning'],
-              'low'  => ['label'=>'Low Risk','class'=>'badge-success']];
+    $map   = ['high'   => ['label' => 'High Risk',   'class' => 'badge-danger'],
+              'medium' => ['label' => 'Medium Risk',  'class' => 'badge-warning'],
+              'low'    => ['label' => 'Low Risk',     'class' => 'badge-success']];
     $b = $map[$level];
     return "<span class=\"badge {$b['class']}\">{$b['label']} (" . round($probability) . "%)</span>";
 }
@@ -303,10 +318,10 @@ function timeAgo(string $datetime): string {
     $now  = new DateTime();
     $then = new DateTime($datetime);
     $diff = $now->diff($then);
-    if ($diff->days > 30)  return $then->format('M j, Y');
-    if ($diff->days >= 1)  return $diff->days  . 'd ago';
-    if ($diff->h >= 1)     return $diff->h     . 'h ago';
-    if ($diff->i >= 1)     return $diff->i     . 'm ago';
+    if ($diff->days > 30) return $then->format('M j, Y');
+    if ($diff->days >= 1) return $diff->days . 'd ago';
+    if ($diff->h >= 1)    return $diff->h    . 'h ago';
+    if ($diff->i >= 1)    return $diff->i    . 'm ago';
     return 'just now';
 }
 

--- a/src/pages/incident_detail.php
+++ b/src/pages/incident_detail.php
@@ -20,7 +20,7 @@ if (!$incident) {
     exit;
 }
 
-// Access control: elder can only see their own; caregiver sees linked elders; admin sees all
+// Access control: elder sees own; caregiver sees linked elders; admin sees all
 $db = getDB();
 if ($user['role'] === 'elder' && $incident['user_id'] != $user['user_id']) {
     header('Location: ' . APP_URL . '/pages/dashboard.php');
@@ -38,26 +38,47 @@ if ($user['role'] === 'caregiver') {
     }
 }
 
-// Handle admin status update
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && in_array($user['role'], ['admin','caregiver'])) {
+// ── Handle POST actions ───────────────────────────────────────
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+
+    // CSRF failure → 403 immediately
     if (!verifyCsrf($_POST['csrf_token'] ?? '')) {
+        http_response_code(403);
         setFlash('danger', 'Invalid form token.');
-    } else {
+        header('Location: ' . APP_URL . '/pages/incident_detail.php?id=' . $incidentId);
+        exit;
+    }
+
+    $action = $_POST['action'] ?? 'update_status';
+
+    // ── Issue #3: Admin edits scam type ───────────────────────
+    if ($action === 'edit_scam_type' && $user['role'] === 'admin') {
+        $newCategory = trim(strip_tags($_POST['scam_category'] ?? ''));
+        if ($newCategory === '' || strlen($newCategory) > 100) {
+            setFlash('danger', 'Scam type must be between 1 and 100 characters.');
+        } elseif (updateScamCategory($incidentId, $newCategory)) {
+            setFlash('success', 'Scam type updated.');
+        } else {
+            setFlash('danger', 'Could not update scam type — no analysis record found.');
+        }
+
+    // ── Status update (admin + caregiver) ────────────────────
+    } elseif ($action === 'update_status' && in_array($user['role'], ['admin', 'caregiver'])) {
         $newStatus = $_POST['status'] ?? '';
         if ($newStatus) {
             updateIncidentStatus($incidentId, $newStatus);
             setFlash('success', 'Status updated.');
         }
     }
+
     header('Location: ' . APP_URL . '/pages/incident_detail.php?id=' . $incidentId);
     exit;
 }
 
-$probability  = (float)($incident['scam_probability'] ?? 0);
-$riskLevel    = getRiskLevel($probability);
-$tactics      = json_decode($incident['manipulation_tactics'] ?? '[]', true) ?: [];
+$probability = (float)($incident['scam_probability'] ?? 0);
+$riskLevel   = getRiskLevel($probability);
+$tactics     = json_decode($incident['manipulation_tactics'] ?? '[]', true) ?: [];
 
-// Get the owner's name
 $ownerStmt = $db->prepare('SELECT full_name FROM users WHERE user_id=?');
 $ownerStmt->execute([$incident['user_id']]);
 $ownerName = $ownerStmt->fetchColumn();
@@ -69,19 +90,22 @@ include __DIR__ . '/../includes/header.php';
 <div class="detail-container">
 
     <div class="detail-header">
-        <a href="<?= APP_URL ?>/pages/<?= $user['role'] === 'elder' ? 'my_incidents' : 'incidents' ?>.php"
+        <a href="<?= e(APP_URL) ?>/pages/<?= $user['role'] === 'elder' ? 'my_incidents' : 'incidents' ?>.php"
            class="back-link">← Back to Reports</a>
-        <h1>Scam Report #<?= $incidentId ?></h1>
+        <h1>Scam Report #<?= (int)$incidentId ?></h1>
         <div class="detail-meta">
             <span>Submitted by <strong><?= e($ownerName) ?></strong></span>
-            <span><?= date('F j, Y g:i A', strtotime($incident['submitted_at'])) ?></span>
+            <span><?= e(date('F j, Y g:i A', strtotime($incident['submitted_at']))) ?></span>
             <span class="status-badge status-<?= e($incident['status']) ?>"><?= e(ucfirst($incident['status'])) ?></span>
+            <?php if (!empty($incident['admin_override'])): ?>
+                <span class="badge badge-info" title="Scam type was manually edited by an admin">✏️ Edited</span>
+            <?php endif; ?>
         </div>
     </div>
 
     <?php if ($incident['scam_probability'] !== null): ?>
     <!-- ── AI RESULT CARD ─────────────────────────────────────── -->
-    <div class="result-card result-<?= $riskLevel ?>">
+    <div class="result-card result-<?= e($riskLevel) ?>">
         <div class="result-score-area">
             <div class="risk-gauge">
                 <div class="gauge-fill" style="width: <?= round($probability) ?>%"></div>
@@ -134,23 +158,24 @@ include __DIR__ . '/../includes/header.php';
         <?php if ($incident['image_path'] && file_exists($incident['image_path'])): ?>
         <div class="submission-image">
             <h3>Attached Screenshot</h3>
-            <img src="<?= APP_URL ?>/uploads/<?= e(basename($incident['image_path'])) ?>"
+            <img src="<?= e(APP_URL) ?>/uploads/<?= e(basename($incident['image_path'])) ?>"
                  alt="Submitted screenshot" class="screenshot-img">
         </div>
         <?php endif; ?>
     </div>
 
-    <!-- ── ADMIN/CAREGIVER CONTROLS ──────────────────────────── -->
-    <?php if (in_array($user['role'], ['admin','caregiver'])): ?>
+    <!-- ── ADMIN / CAREGIVER CONTROLS ────────────────────────── -->
+    <?php if (in_array($user['role'], ['admin', 'caregiver'])): ?>
     <div class="admin-controls">
         <h2>Update Status</h2>
-        <form method="POST" action="">
+        <form method="POST">
             <?= csrfField() ?>
+            <input type="hidden" name="action" value="update_status">
             <div class="form-inline">
                 <select name="status">
-                    <?php foreach (['pending','analyzed','reviewed','dismissed'] as $s): ?>
-                        <option value="<?= $s ?>" <?= $incident['status']==$s ? 'selected':'' ?>>
-                            <?= ucfirst($s) ?>
+                    <?php foreach (['pending', 'analyzed', 'reviewed', 'dismissed'] as $s): ?>
+                        <option value="<?= e($s) ?>" <?= $incident['status'] === $s ? 'selected' : '' ?>>
+                            <?= e(ucfirst($s)) ?>
                         </option>
                     <?php endforeach; ?>
                 </select>
@@ -159,8 +184,26 @@ include __DIR__ . '/../includes/header.php';
         </form>
 
         <?php if ($user['role'] === 'admin'): ?>
-        <div class="danger-zone">
-            <a href="<?= APP_URL ?>/api/delete_incident.php?id=<?= $incidentId ?>&csrf=<?= urlencode(csrfToken()) ?>"
+        <!-- ── Issue #3: Edit scam type ──────────────────────── -->
+        <h2 class="mt-4">Edit Scam Type</h2>
+        <form method="POST">
+            <?= csrfField() ?>
+            <input type="hidden" name="action" value="edit_scam_type">
+            <div class="form-inline">
+                <input type="text"
+                       name="scam_category"
+                       class="form-control"
+                       maxlength="100"
+                       value="<?= e($incident['scam_category'] ?? '') ?>"
+                       placeholder="e.g. phone_scam"
+                       required>
+                <button type="submit" class="btn btn-warning">Save Scam Type</button>
+            </div>
+            <small class="text-muted">Use underscores for spaces (e.g. romance_scam). Max 100 chars.</small>
+        </form>
+
+        <div class="danger-zone mt-4">
+            <a href="<?= e(APP_URL) ?>/api/delete_incident.php?id=<?= (int)$incidentId ?>&csrf=<?= urlencode(csrfToken()) ?>"
                class="btn btn-danger"
                onclick="return confirm('Permanently delete this incident?')">
                 🗑️ Delete Incident
@@ -170,10 +213,10 @@ include __DIR__ . '/../includes/header.php';
     </div>
     <?php endif; ?>
 
-    <!-- ── ELDER DELETE OWN REPORT ───────────────────────────── -->
+    <!-- ── ELDER: DELETE OWN REPORT ──────────────────────────── -->
     <?php if ($user['role'] === 'elder' && $incident['user_id'] == $user['user_id']): ?>
     <div class="elder-controls">
-        <a href="<?= APP_URL ?>/api/delete_incident.php?id=<?= $incidentId ?>&csrf=<?= urlencode(csrfToken()) ?>"
+        <a href="<?= e(APP_URL) ?>/api/delete_incident.php?id=<?= (int)$incidentId ?>&csrf=<?= urlencode(csrfToken()) ?>"
            class="btn btn-outline-danger btn-sm"
            onclick="return confirm('Remove this report from your history?')">
             Remove This Report


### PR DESCRIPTION
## Fixes

Closes #3
Closes #5

---

### Issue #3 — Admin can edit scam type

**Root cause:** No UI or handler existed for updating `scam_category` after AI analysis.

**Changes:**
- `helpers.php` — added `updateScamCategory(int $incidentId, string $category): bool` which updates `analysis.scam_category` and sets `admin_override = 1` as an audit flag
- `incident_detail.php` — added an "Edit Scam Type" form in the admin controls section (admin-only). Input is sanitized with `strip_tags()` + `trim()`, length-capped at 100 chars, and uses CSRF protection. An ✏️ Edited badge appears on incidents where the admin has overridden the AI category.

---

### Issue #5 — Revoked caregiver/elder links can't be re-linked

**Root cause:** `revokeLink()` was setting `status = 'revoked'` but the `UNIQUE KEY (elder_user_id, caregiver_user_id)` on `account_links` prevented a new `INSERT` for the same pair, making re-linking impossible.

**Fix:**
- `helpers.php` — `revokeLink()` now `DELETE`s the row instead of updating its status. This clears the unique constraint, allowing `linkCaregiverToElder()` to re-insert a fresh `pending` link as normal.

---

### Security practices applied
- CSRF on all new forms
- `http_response_code(403)` on CSRF failure
- `strip_tags()` + `trim()` + length check on scam category input
- `e()` (ENT_QUOTES, UTF-8) on all new output
- Explicit `(int)` cast on `$incidentId` in all URLs
